### PR TITLE
improve 01_breadth-first_search.py

### DIFF
--- a/06_breadth-first_search/python/01_breadth-first_search.py
+++ b/06_breadth-first_search/python/01_breadth-first_search.py
@@ -16,8 +16,8 @@ graph["jonny"] = []
 def search(name):
     search_queue = deque()
     search_queue += graph[name]
-    # This array is how you keep track of which people you've searched before.
-    searched = []
+    # This is how you keep track of which people you've searched before.
+    searched = set()
     while search_queue:
         person = search_queue.popleft()
         # Only search this person if you haven't already searched them.
@@ -28,7 +28,7 @@ def search(name):
             else:
                 search_queue += graph[person]
                 # Marks this person as searched
-                searched.append(person)
+                searched.add(person)
     return False
 
 search("you")


### PR DESCRIPTION
Reading about breadth-first search algorithm I was a little surprised, why to store the visited nodes a list was used instead of a set, since the time complexity of searching in a set is O(1), and a list is O(n): (line: "**if person not in searched:**").
Perhaps this is because the set data structure was not introduced, but only a dictionary (a dictionary is still better to use than a list).