### PR TITLE
Fix recursive sum

### DIFF
--- a/04_quicksort/ts/02_recursive_sum.ts
+++ b/04_quicksort/ts/02_recursive_sum.ts
@@ -1,9 +1,10 @@
 function sum(arr: number[]): number {
-    if (arr.length === 1) {
-        return arr[0];
+    if (arr.length === 0) {
+        return 0;
     }
 
     return arr[0] + sum(arr.slice(1));
 }
 
-console.log(sum([1, 2, 3, 4]));
+console.log(sum([])); // 0
+console.log(sum([1, 2, 3, 4])); // 10


### PR DESCRIPTION
According to the book, if there's no elements in the list, it should return `0`.
If you try the code before with `sum([])` you'll  get `Uncaught RangeError: Maximum call stack size exceeded` , since it's not possible to get `slice(1)` from an empty list.

The code above fix this issue and make it work as it's expected from the book.