### PR TITLE
Update 05_quicksort.php

### DIFF
--- a/04_quicksort/php/05_quicksort.php
+++ b/04_quicksort/php/05_quicksort.php
@@ -6,7 +6,7 @@ function quicksort(array $array) {
         return $array;
     } else {
         // recursive case
-        $pivot = $array[0];
+        $pivot = $array[array_key_first($array)];
         var_dump($array);
 
         // sub-array of all the elements less than the pivot


### PR DESCRIPTION
In some cases, the index of the first element of the array ($array[0]) is missing and we get a `Notice:  Undefined offset: 0`
For example an array can start at index 2, so use array_key_first() function.

Try this:
```php
quicksort([4, 5, 2, 3, 100, 1, 90, 12, 10, 23]);
```