### PR TITLE
05_hash_tables javascript. Freeze hashtable

### DIFF
--- a/05_hash_tables/javascript/03_hashtable.js
+++ b/05_hash_tables/javascript/03_hashtable.js
@@ -146,6 +146,11 @@ const HashTable = function(obj) {
       return this.getValues();
     }
   });
+  
+  /**
+   * Freeze hashtable
+   */
+  Object.freeze(this);
 };
 
 const hashtable = new HashTable({ one: 1, two: 2, three: 3, cuatro: 4 });


### PR DESCRIPTION
I think the hash table needs to be frozen.

```
delete hashtable.set;
delete hashtable.has;
hashtable._items = {}
console.log(hashtable._items); // { one: 1, two: 2, three: 3, cuatro: 4 }
hashtable.set('test', 'value');
console.log(hashtable._items); // { one: 1, two: 2, three: 3, cuatro: 4, test: 'value' }
hashtable.set('test', 'change');
console.log(hashtable._items); // { one: 1, two: 2, three: 3, cuatro: 4, test: 'change' }
hashtable.remove('test');
console.log(hashtable._items); // { one: 1, two: 2, three: 3, cuatro: 4 }
console.log(hashtable);
```