### PR TITLE
satisfy CA1829 for C# binary search

### DIFF
--- a/01_introduction_to_algorithms/csharp/01_binary_search/Program.cs
+++ b/01_introduction_to_algorithms/csharp/01_binary_search/Program.cs
@@ -16,7 +16,7 @@ namespace ConsoleApplication
         private static int? BinarySearch(IList<int> list, int item)
         {
             var low = 0;
-            var high = list.Count() - 1;
+            var high = list.Count - 1;
 
             while (low <= high)
             {


### PR DESCRIPTION
CA1829: Use Length/Count property instead of Enumerable.Count method

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1829