### PR TITLE
Fix: Replace Union with Concat in C# Quicksort implementation

### DIFF
--- a/04_quicksort/csharp/05_quicksort/Program.cs
+++ b/04_quicksort/csharp/05_quicksort/Program.cs
@@ -18,7 +18,7 @@ namespace ConsoleApplication
             var pivot = list.First();
             var less = list.Skip(1).Where(i => i <= pivot);
             var greater = list.Skip(1).Where(i => i > pivot);
-            return QuickSort(less).Union(new List<int> { pivot }).Union(QuickSort(greater));
+            return QuickSort(less).Concat(new List<int> { pivot }).Concat(QuickSort(greater));
         }
     }
 }


### PR DESCRIPTION
Currently, the C# implementation uses `.Union()`, which removes duplicate values from the collection (e.g., `[10, 10, 5]` becomes `[5, 10]`).

This behavior differs from the original Python implementation provided in the book, where list concatenation (`+`) is used, preserving all elements.

This PR replaces `.Union()` with `.Concat()` to ensure all elements from the original list are preserved in the sorted output.