### PR TITLE
Update 05_quicksort.swift for Best and Worst case

### DIFF
--- a/04_quicksort/swift/05_quicksort.swift
+++ b/04_quicksort/swift/05_quicksort.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-//The following implementation of quick sort is little more classic than described in the book, but we have two use this one because of some “slice” feature limitation with array on Swift 3. Main concept is the same
-func quicksort <T : Comparable> (_ array : [T]) -> [T] {
+//Worst case performance: O(n^2) when the smallest or largest element is always chosen as the pivot. This can happen when the input array is already sorted or reverse sorted.
+func quicksort_worst <T : Comparable> (_ array : [T]) -> [T] {
     // base case, arrays with 0 or 1 element are already "sorted"
     guard array.count > 1 else { return array }
-    // recursive case
+    // recursive case - 0th element for worst case
     let pivot = array[0]
     // sub-array of all the elements less than the pivot
     let less = array.filter { $0 < pivot }
@@ -12,7 +12,24 @@ func quicksort <T : Comparable> (_ array : [T]) -> [T] {
     let equal = array.filter { $0 == pivot }
     // sub-array of all the elements greater than the pivot
     let greater = array.filter { $0 > pivot }
-    return quicksort(less) + equal + quicksort(greater)
+    return quicksort_worst(less) + equal + quicksort_worst(greater)
 }
 
-print(quicksort([1, 5, 10, 25, 16, 1])) // => [1, 1, 5, 10, 16, 25]
+print(quicksort_worst([1, 5, 10, 25, 16, 1])) // => [1, 1, 5, 10, 16, 25]
+
+//Best case performance: O(n log n) when the pivot divides the array into two equal
+func quicksort_best <T : Comparable> (_ array : [T]) -> [T] {
+    // base case, arrays with 0 or 1 element are already "sorted"
+    guard array.count > 1 else { return array }
+    // recursive case - random element for best case
+    let pivot = array[Int.random(in: 0 ..< array.count)]
+    // sub-array of all the elements less than the pivot
+    let less = array.filter { $0 < pivot }
+    // sub-array of all the elements equal to the pivot
+    let equal = array.filter { $0 == pivot }
+    // sub-array of all the elements greater than the pivot
+    let greater = array.filter { $0 > pivot }
+    return quicksort_best(less) + equal + quicksort_best(greater)
+}
+
+print(quicksort_best([1, 5, 10, 25, 16, 1])) // => [1, 1, 5, 10, 16, 25]


### PR DESCRIPTION
Update the Quicksort algorithm for Swift, to have the best case on Big O. 

I rewrote the function to consider both cases:

1 - Worst case: O(nˆ2)
The quicksort was renamed for quicksort_worst, as the function uses pivot[0].
On the worst case, using the first element as pivot, we have the big O as (n * n = nˆ2)

2 - Best case: O(n log n)
Now, I added a new function called quicksort_best, as the function uses pivot[Int.random(in: 0 ..< array.count)]
On the best case, using any random element, we get the best performance and the average case, what gives us the big O of (n * log n = n log n)
