### PR TITLE
Add idiomatic in-place quicksort example (Rust)

### DIFF
--- a/04_quicksort/rust/src/main.rs
+++ b/04_quicksort/rust/src/main.rs
@@ -1,3 +1,5 @@
+mod quicksort_idiomatic;
+
 fn rec_sum(list: &[usize]) -> usize {
     match list.get(0) {
         Some(x) => x + rec_sum(&list[1..]),
@@ -60,6 +62,10 @@ fn main() {
     println!("sum: {}", rec_sum(&list));
     println!("count: {}", rec_count(&list));
     println!("maximum: {:?}", maximum(&list));
+
+    let mut list_mut = vec![10, 5, 2, 12, 3];
+    quicksort_idiomatic::quicksort(&mut list_mut);
+    println!("quicksort idiomatic: {:?}", list_mut);
 }
 
 #[cfg(test)]

--- a/04_quicksort/rust/src/quicksort_idiomatic.rs
+++ b/04_quicksort/rust/src/quicksort_idiomatic.rs
@@ -1,0 +1,88 @@
+pub fn quicksort<T: Ord>(list: &mut [T]) {
+    if list.len() < 2 {
+        return;
+    }
+
+    let pivot_index = partition(list);
+
+    let (left, right) = list.split_at_mut(pivot_index);
+
+    quicksort(left);
+    quicksort(&mut right[1..]); // right[0] is the pivot, already placed
+}
+
+fn partition<T: Ord>(list: &mut [T]) -> usize {
+    let pivot_index = list.len() - 1;
+    let mut i = 0;
+
+    for j in 0..pivot_index {
+        if list[j] <= list[pivot_index] {
+            list.swap(i, j);
+            i += 1;
+        }
+    }
+
+    list.swap(i, pivot_index);
+    i
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_list() {
+        let mut list: Vec<i32> = vec![];
+        quicksort(&mut list);
+        assert_eq!(list, Vec::<i32>::new());
+    }
+
+    #[test]
+    fn single_element() {
+        let mut list = vec![42];
+        quicksort(&mut list);
+        assert_eq!(list, vec![42]);
+    }
+
+    #[test]
+    fn already_sorted() {
+        let mut list = vec![1, 2, 3, 4, 5];
+        quicksort(&mut list);
+        assert_eq!(list, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn reverse_sorted() {
+        let mut list = vec![5, 4, 3, 2, 1];
+        quicksort(&mut list);
+        assert_eq!(list, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn with_duplicates() {
+        let mut list = vec![3, 1, 3, 2, 1];
+        quicksort(&mut list);
+        assert_eq!(list, vec![1, 1, 2, 3, 3]);
+    }
+
+    #[test]
+    fn general_case() {
+        let mut list = vec![9, 5, 1, 8, 3, 7, 2, 6, 4];
+        quicksort(&mut list);
+        assert_eq!(list, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    #[test]
+    fn all_equal_elements() {
+        let mut list = vec![7, 7, 7, 7];
+        quicksort(&mut list);
+        assert_eq!(list, vec![7, 7, 7, 7]);
+    }
+
+    #[test]
+    fn works_with_strings() {
+        let mut list = vec!["banana", "apple", "cherry"];
+        quicksort(&mut list);
+        assert_eq!(list, vec!["apple", "banana", "cherry"]);
+    }
+}


### PR DESCRIPTION
## Summary
- 04_quicksort/rust already has a quicksort ported from the book (clone-based, builds new `less`/`greater` Vecs each call).
- This adds a second, small module (`src/quicksort_idiomatic.rs`) showing the same algorithm written in-place, using `split_at_mut`/`swap` — one way to satisfy the borrow checker's non-aliasing rules without cloning.
- Existing `quicksort` in `main.rs` is untouched; both versions run and print from `main` so the comparison is visible.

## Why
This isn't meant to replace the existing version, it's here to show what quicksort looks like when you write it around Rust's borrowing rules instead of cloning to avoid them: mutable slices, in-place swaps, and `split_at_mut` to get two non-overlapping `&mut` borrows past the compiler. Keeping both versions side by side makes the tradeoff visible rather than asserting one is correct.


## Test plan
- [x] `cargo test` — 11 passed, 0 failed

<img width="2832" height="1700" alt="image" src="https://github.com/user-attachments/assets/604e4a4d-0ff5-4707-a761-fc2064ccf8ee" />
